### PR TITLE
Unterschiedliche Icons für gewonnene Pistolenrunden im Match-Detail

### DIFF
--- a/src/theme/stylesheets/base/_variables.scss
+++ b/src/theme/stylesheets/base/_variables.scss
@@ -31,3 +31,5 @@ $page-width: 1200px;
 
 // Pace
 $pace-progress-color: $orange;
+
+$match-pistol-image: 'http://i.imgur.com/fTKaIuE.png';

--- a/src/theme/stylesheets/dark.scss
+++ b/src/theme/stylesheets/dark.scss
@@ -9,6 +9,8 @@ $secondary-font-color: tint($secondary-bg-color, 40%);
 $nav-bg-color: $secondary-bg-color;
 $base-border: 1px solid $secondary-bg-color;
 
+$match-pistol-image: 'http://i.imgur.com/yfWEb5v.png';
+
 @import "modules/modules";
 
 @import "layout/layout";

--- a/src/theme/stylesheets/layout/_matches.scss
+++ b/src/theme/stylesheets/layout/_matches.scss
@@ -126,6 +126,24 @@ ul.match_subs li span.score {
     }
 }
 
+ul.match_subs li span.score span.pist {
+    img {
+        width: 0;
+        height: 0;
+        padding: 4px 6px;
+        margin-top: 6px;
+    }
+
+    &:first-child img {
+        background-image: url($match-pistol-image);
+    }
+
+    &:last-child img {
+        background-image: url($match-pistol-image);
+        transform: scaleX(-1);
+    }
+}
+
 ul.match_subs li span.opp.opp2 {
     text-align: left;
     img {


### PR DESCRIPTION
Sieht aktuell etwas unschön aus mit dem Hintergrund. Font-Awesome hat keinen Pistolen-Icon.

Evtl. die Icons anstatt auf imgur über den `assets/` Ordner ausliefern?
# Alt

![screenshot-www readmore de 2015-07-19 23-50-48](https://cloud.githubusercontent.com/assets/502368/8768025/a3cfc504-2e71-11e5-8659-5d3626e9cc3f.png)
![screenshot-www readmore de 2015-07-19 23-51-24](https://cloud.githubusercontent.com/assets/502368/8768026/a3e21e2a-2e71-11e5-97a2-eaac138e6df1.png)
# Neu

![screenshot-www readmore de 2015-07-19 23-51-59](https://cloud.githubusercontent.com/assets/502368/8768027/a3e36ffa-2e71-11e5-92de-9b253ad4e3ce.png)
![screenshot-www readmore de 2015-07-19 23-52-22](https://cloud.githubusercontent.com/assets/502368/8768028/a3e525e8-2e71-11e5-83f8-e9e9addaabb4.png)

Browser-Support für transform: http://caniuse.com/#feat=transforms2d
